### PR TITLE
Fix -Q flag

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7821,7 +7821,7 @@ int main(int argc, char** argv) {
   gettimeofday(&tv, &tz);
   srandom(tv.tv_sec ^ tv.tv_usec ^ getpid());
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:Q:p:")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:Qp:")) > 0)
 
     switch (opt) {
 


### PR DESCRIPTION
The change that added the `-p` command line argument broke the `-Q` flag, which is not supposed to have an optional argument and thus should not be followed by `:` in `getopt`.