### PR TITLE
Fix the compilation error in llvm_mode when using make clean all

### DIFF
--- a/llvm_mode/Makefile
+++ b/llvm_mode/Makefile
@@ -96,8 +96,8 @@ endif
 test_build: $(PROGS)
 	@echo "[*] Testing the CC wrapper and instrumentation output..."
 	unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO; AFL_QUIET=1 AFL_PATH=. AFL_CC=$(CC) ../afl-clang-fast $(CFLAGS) ../test-instr.c -o test-instr $(LDFLAGS)
-	echo 0 | ../afl-showmap -m none -q -o .test-instr0 ./test-instr
-	echo 1 | ../afl-showmap -m none -q -o .test-instr1 ./test-instr
+	../afl-showmap -m none -q -o .test-instr0 ./test-instr < /dev/null
+        echo 1 | ../afl-showmap -m none -q -o .test-instr1 ./test-instr
 	@rm -f test-instr
 	@cmp -s .test-instr0 .test-instr1; DR="$$?"; rm -f .test-instr0 .test-instr1; if [ "$$DR" = "0" ]; then echo; echo "Oops, the instrumentation does not seem to be behaving correctly!"; echo; echo "Please ping <lcamtuf@google.com> to troubleshoot the issue."; echo; exit 1; fi
 	@echo "[+] All right, the instrumentation seems to be working!"


### PR DESCRIPTION
When executing the command make clean all in the llvm_mode directory, an error occurs during the test_build phase (as indicated in the Makefile). The error message is as follows:

```
unset AFL_USE_ASAN AFL_USE_MSAN AFL_INST_RATIO; AFL_QUIET=1 AFL_PATH=. AFL_CC=clang ../afl-clang-fast -O3 -funroll-loops -Wall -D_FORTIFY_SOURCE=2 -g -Wno-pointer-sign -DAFL_PATH=\"/usr/local/lib/afl\" -DBIN_PATH=\"/usr/local/bin\" -DVERSION=\"2.51b\"  ../test-instr.c -o test-instr 
echo 0 | ../afl-showmap -m none -q -o .test-instr0 ./test-instr
echo 1 | ../afl-showmap -m none -q -o .test-instr1 ./test-instr

Oops, the instrumentation does not seem to be behaving correctly!

Please ping <lcamtuf@google.com> to troubleshoot the issue.
```

Note that this error doesn't impact the proper functioning of `afl-clang-fast`.

To resolve this issue, I made the necessary modifications to the code based on the changes made in the latest version of the `Makefile` in the google/AFL repository ([link](https://github.com/google/AFL/blob/61037103ae3722c8060ff7082994836a794f978e/llvm_mode/Makefile#L102))